### PR TITLE
🔧 Add explicit `ci` job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,12 @@
 name: Run build on push
-on: [push]
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: "0 7 * * 1,3,5"
 env:
   VBUILD_UNIT_TESTS: true
 jobs:
@@ -118,3 +125,14 @@ jobs:
           make test
 
       - run: echo "🍏 This job's status is ${{ job.status }}."
+
+  ci:
+    needs:
+      - run-build-mac
+      - run-build-ubuntu
+      - run-build-windows
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - run: exit 1
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}


### PR DESCRIPTION
- having a job named `ci` simplifies status check configurations with terraform
- also adds a schedule to avoid surprise build failures due to changes to deps, as happened when openSSL recently started requiring a newer version of conan