### PR TITLE
[hotfix] CMake find_package for MS GSL is incorrect

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 find_package("OpenSSL")
 find_package("Boost")
-find_package("ms_gsl")
+find_package("Microsoft.GSL")
 find_package("LibXml2")
 find_package("nlohmann_json")
 find_package("jwt-cpp")
@@ -21,4 +21,3 @@ find_package("jwt-cpp")
 include_directories(${CONAN_INCLUDE_DIRS})
 
 add_subdirectory(src)
-


### PR DESCRIPTION
According to the upstream, it should `Microsoft.GSL` instead of `ms_gsl`:

https://github.com/microsoft/GSL#usage-in-cmake