### PR TITLE
📌 Let quickstart follow opentdf/main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Git clone opentdf 
         run: |
-          git clone --depth 1 --branch feature/1.0.0-better https://github.com/opentdf/opentdf.git
+          git clone --depth 1 https://github.com/opentdf/opentdf.git
       
       - uses: yokawasa/action-setup-kube-tools@v0.8.0
         with:


### PR DESCRIPTION
Current policy is to have main/quickstart always follow latest release of opentdf charts, and only merge to main on a release, so this should give us the intended behavior (works with latest stable).

ALTERNATIVE: Create a long lived branch called `lts` or similar if we want to track oldest supported backend