### PR TITLE
[PLAT-2332] Bump conan version to fix build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
     - cron: "0 7 * * 1,3,5"
 env:
   VBUILD_UNIT_TESTS: true
-  CONAN_VER: 1.53.0
+  CONAN_VER: 1.54.0
 jobs:
 
   run-build-ubuntu:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 1.3.8
  - PLAT-2240 - RCA support in C++ Open SDK
+ - PLAT-2332 - Bump conan version to fix build
 
 1.3.7 
  -  PLAT-2254 - Fix the CRC calculation for 64 bit zip in openTDF C++ SDK


### PR DESCRIPTION
3rd party package changed their minimum conan version requirement:

```
passed-in-te… │ libbacktrace/cci.20210118: Downloaded recipe revision 0
passed-in-te… │ ERROR: libbacktrace/cci.20210118: Cannot load recipe.
passed-in-te… │ Error loading conanfile at '/home/runner/.conan/data/libbacktrace/cci.20210118/_/_/export/conanfile.py': Current Conan version (1.53.0) does not satisfy the defined one (>=1.54.0).
passed-in-te… │ ERROR: conanbuildinfo.txt file not found in /home/runner/work/client-cpp/client-cpp/src/build
passed-in-te… │ It is required for this command
```