### PR TITLE
Bump conan version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
     - cron: "0 7 * * 1,3,5"
 env:
   VBUILD_UNIT_TESTS: true
-  CONAN_VER: 1.54.0
+  CONAN_VER: 1.57.0
 jobs:
 
   run-build-ubuntu:


### PR DESCRIPTION
libxml2 requires a newer conan version.  Change to 1.57.0 to avoid the resulting build fail.