### PR TITLE
[PLAT-2428] Qualify move call to avoid compile warnings in virtru-tdf3-cpp build

### DIFF
--- a/src/lib/include/crypto/crypto_utils.h
+++ b/src/lib/include/crypto/crypto_utils.h
@@ -77,7 +77,7 @@ namespace virtru::crypto {
     class CryptoException : public std::runtime_error {
     public:
         explicit CryptoException(std::string &&what, int code = 1) :
-                std::runtime_error{"Error code "s + std::to_string(code) + ". " + move(what)},
+                std::runtime_error{"Error code "s + std::to_string(code) + ". " + std::move(what)},
                 m_code{code} {}
 
         int code() const noexcept {

--- a/src/lib/include/tdf_exception.h
+++ b/src/lib/include/tdf_exception.h
@@ -57,10 +57,10 @@ namespace virtru {
 
         //only log line number for DEBUG and TRACE
         if(IsLogLevelDebug() || IsLogLevelTrace()){
-            throw Exception { os.str() + move (errorStringPrefix), code};
+            throw Exception { os.str() + std::move (errorStringPrefix), code};
         }
         else{
-            throw Exception { move (errorStringPrefix), code};
+            throw Exception { std::move (errorStringPrefix), code};
         }
 
          


### PR DESCRIPTION
During the virtru layer build, the unqualified calls to std::move create compilation warnings.  Add std:: to avoid that.