### PR TITLE
[PLAT-2015] Avoid compiler warnings about namespace for move()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+1.3.11
+ - PLAT-2015 - More compiler warning cleanup
+
+1.3.10
+ - No changes - version added to trigger Conan Center Index automation
+
 1.3.9
  - PLAT-2340 - OpenTDF C++ SDK - TDF reader and writer interface should be public
 

--- a/src/lib/src/crypto/crypto_utils.cpp
+++ b/src/lib/src/crypto/crypto_utils.cpp
@@ -145,13 +145,13 @@ namespace virtru::crypto {
         //only log line numbers for DEBUG and TRACE
         if(IsLogLevelDebug() || IsLogLevelTrace()){
             throw CryptoException {
-                os.str() + move (errorStringPrefix) + openssl_error_string_buffer.data(),
+                os.str() + std::move (errorStringPrefix) + openssl_error_string_buffer.data(),
                 static_cast<int>(error)
             };
         }
         else{
             throw CryptoException {
-                move (errorStringPrefix) + openssl_error_string_buffer.data(),
+                std::move (errorStringPrefix) + openssl_error_string_buffer.data(),
                 static_cast<int>(error)
             };
         }

--- a/src/lib/src/network/http_client_service.cpp
+++ b/src/lib/src/network/http_client_service.cpp
@@ -67,7 +67,7 @@ namespace virtru :: network {
             ServiceCallback cb_;
             void report (ErrorCode ec ) {
                 if ( cb_ ) {
-                    cb_ ( ec, move ( res_ ) );
+                    cb_ ( ec, std::move ( res_ ) );
                     cb_ = nullptr;
                 }
             }
@@ -80,11 +80,11 @@ namespace virtru :: network {
                     HttpRequest && req,
                     ServiceCallback && cb
             ):
-                    host {move ( host ) },
+                    host {std::move ( host ) },
                     resolver_ { io },
                     stream_ { io, ctx },
-                    req_ { move ( req ) },
-                    cb_ { move ( cb ) }
+                    req_ { std::move ( req ) },
+                    cb_ { std::move ( cb ) }
             {
                 parser_.body_limit((std::numeric_limits<std::uint64_t>::max)());
             }
@@ -180,7 +180,7 @@ namespace virtru :: network {
 
             void on_read_headers (
                     bs :: error_code ec,
-                    std::size_t bytes_transferred
+                    std::size_t /*bytes_transferred*/
             ) {
                 if ( ec )
                     return report ( ec );
@@ -231,7 +231,7 @@ namespace virtru :: network {
             ServiceCallback cb_;
             void report (ErrorCode ec ) {
                 if ( cb_ ) {
-                    cb_ ( ec, move ( res_ ) );
+                    cb_ ( ec, std::move ( res_ ) );
                     cb_ = nullptr;
                 }
             }
@@ -243,11 +243,11 @@ namespace virtru :: network {
                     HttpRequest && req,
                     ServiceCallback && cb
             ):
-                    host {move ( host ) },
+                    host {std::move ( host ) },
                     resolver_ { io },
                     stream_ { io },
-                    req_ { move ( req ) },
-                    cb_ { move ( cb ) }
+                    req_ { std::move ( req ) },
+                    cb_ { std::move ( cb ) }
             {
                 parser_.body_limit((std::numeric_limits<std::uint64_t>::max)());
             }
@@ -323,7 +323,7 @@ namespace virtru :: network {
 
             void on_read_headers (
                     bs :: error_code ec,
-                    std::size_t bytes_transferred
+                    std::size_t /*bytes_transferred*/
             ) {
                 if ( ec )
                     return report ( ec );
@@ -442,12 +442,12 @@ namespace virtru :: network {
         m_request.method(HttpVerb::get);
 
         if (isSSLSocket()) {
-            std::make_shared<SSLSession>(move(m_host), ioContext, m_sslContext,
-                                         move(m_request), move(callback))->start(m_schema);
+            std::make_shared<SSLSession>(std::move(m_host), ioContext, m_sslContext,
+                                         std::move(m_request), std::move(callback))->start(m_schema);
         }
         else {
-            std::make_shared<Session>(move(m_host), ioContext,
-                                      move(m_request), move(callback))->start(m_schema);
+            std::make_shared<Session>(std::move(m_host), ioContext,
+                                      std::move(m_request), std::move(callback))->start(m_schema);
         }
     }
 
@@ -458,12 +458,12 @@ namespace virtru :: network {
         m_request.method(HttpVerb::head);
 
         if (isSSLSocket()) {
-            std::make_shared<SSLSession>(move(m_host), ioContext, m_sslContext,
-                                         move(m_request), move(callback))->start(m_schema);
+            std::make_shared<SSLSession>(std::move(m_host), ioContext, m_sslContext,
+                                         std::move(m_request), std::move(callback))->start(m_schema);
         }
         else {
-            std::make_shared<Session>(move(m_host), ioContext,
-                                      move(m_request), move(callback))->start(m_schema);
+            std::make_shared<Session>(std::move(m_host), ioContext,
+                                      std::move(m_request), std::move(callback))->start(m_schema);
         }
     }
 
@@ -477,12 +477,12 @@ namespace virtru :: network {
         m_request.prepare_payload();
 
         if (isSSLSocket()) {
-            std::make_shared<SSLSession>(move(m_host), ioContext, m_sslContext,
-                                         move(m_request), move(callback))->start(m_schema);
+            std::make_shared<SSLSession>(std::move(m_host), ioContext, m_sslContext,
+                                         std::move(m_request), std::move(callback))->start(m_schema);
         }
         else {
-            std::make_shared<Session>(move(m_host), ioContext,
-                                      move(m_request), move(callback))->start(m_schema);
+            std::make_shared<Session>(std::move(m_host), ioContext,
+                                      std::move(m_request), std::move(callback))->start(m_schema);
         }
     }
 
@@ -496,12 +496,12 @@ namespace virtru :: network {
         m_request.prepare_payload();
 
         if (isSSLSocket()) {
-            std::make_shared<SSLSession>(move(m_host), ioContext, m_sslContext,
-                                         move(m_request), move(callback))->start(m_schema);
+            std::make_shared<SSLSession>(std::move(m_host), ioContext, m_sslContext,
+                                         std::move(m_request), std::move(callback))->start(m_schema);
         }
         else {
-            std::make_shared<Session>(move(m_host), ioContext,
-                                      move(m_request), move(callback))->start(m_schema);
+            std::make_shared<Session>(std::move(m_host), ioContext,
+                                      std::move(m_request), std::move(callback))->start(m_schema);
         }
     }
 
@@ -515,12 +515,12 @@ namespace virtru :: network {
         m_request.prepare_payload();
 
         if (isSSLSocket()) {
-            std::make_shared<SSLSession>(move(m_host), ioContext, m_sslContext,
-                                         move(m_request), move(callback))->start(m_schema);
+            std::make_shared<SSLSession>(std::move(m_host), ioContext, m_sslContext,
+                                         std::move(m_request), std::move(callback))->start(m_schema);
         }
         else {
-            std::make_shared<Session>(move(m_host), ioContext,
-                                      move(m_request), move(callback))->start(m_schema);
+            std::make_shared<Session>(std::move(m_host), ioContext,
+                                      std::move(m_request), std::move(callback))->start(m_schema);
         }
     }
 

--- a/src/lib/src/network/network_util.cpp
+++ b/src/lib/src/network/network_util.cpp
@@ -40,7 +40,7 @@ namespace virtru::network {
                                      const char* fileName, unsigned int lineNumber) {
         std::ostringstream os;
         os << " [" << fileName << ":" << lineNumber << "] ";
-        throw Exception { os.str() + "Network - " + move(errorString), errorCode };
+        throw Exception { os.str() + "Network - " + std::move(errorString), errorCode };
     }
 }  // namespace virtru::network
 


### PR DESCRIPTION
More cleanup of compiler warnings, no functional changes.