### PR TITLE
[PLAT-2460] Fix TDFIsTDF C API function so it is only returning true/false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 1.3.11
  - PLAT-2015 - More compiler warning cleanup
+ - PLAT-2460 - Bug - fix TDFIsTDF C API function so it returns only true/false values
 
 1.3.10
  - No changes - version added to trigger Conan Center Index automation

--- a/src/lib/src/tdf_client_c.cpp
+++ b/src/lib/src/tdf_client_c.cpp
@@ -542,7 +542,8 @@ DLL_PUBLIC bool TDFIsTDF(TDFClientPtr clientPtr,
 
     if (clientPtr == nullptr ||
         storageTypePtr == nullptr) {
-        return TDF_STATUS_INVALID_PARAMS;
+        // Can only return true/false here, so if the answer isn't yes...has to be no
+        return false;
     }
 
     try {
@@ -550,6 +551,7 @@ DLL_PUBLIC bool TDFIsTDF(TDFClientPtr clientPtr,
 
         virtru::TDFStorageType *storage = static_cast<virtru::TDFStorageType *>(storageTypePtr);
 
+        // Analyze supplied data - if exception is thrown, will return false below
         return client->isTDF(*storage);
     } catch (virtru::Exception &e) {
         LogError(e.what());
@@ -559,7 +561,8 @@ DLL_PUBLIC bool TDFIsTDF(TDFClientPtr clientPtr,
     } catch (...) {
         LogDefaultError();
     }
-    return TDF_STATUS_FAILURE;
+    // Can only return true/false here, so if we caught an exception, answer has to be false
+    return false;
 }
 
 #ifdef __cplusplus


### PR DESCRIPTION
This function was trying to return error codes, but the return type is bool.  That potentially means errors would be interpreted as TRUE, since it the error values are nonzero.