### PR TITLE
[108] bug - remove obsolete URL from basic http test

### DIFF
--- a/build-and-run-sanity-test.sh
+++ b/build-and-run-sanity-test.sh
@@ -2,6 +2,7 @@
 
 echo "Building OpenTDF library and run unittests"
 export VRUN_BACKEND_TESTS="true"
+export VBUILD_UNIT_TESTS="true"
 cd ../../src && ./build-all.sh
 
 echo "Build the sample executable using OpenTDF library"

--- a/src/tests/test_http_client_service.cpp
+++ b/src/tests/test_http_client_service.cpp
@@ -28,7 +28,7 @@ BOOST_AUTO_TEST_SUITE(test_http_client_service_suite)
         constexpr auto AcceptHeaderKey = "Accept";
         constexpr auto AcceptHeaderValue = "application/json";
         constexpr auto UserAgentHeaderKey = "User-Agent";
-        constexpr auto UserAgentValuePostFix = virtru::Utils::getUserAgentValuePostFix();
+        auto UserAgentValuePostFix = virtru::Utils::getUserAgentValuePostFix();
 
         auto service = Service::Create(kasUrl);
         service->AddHeader(AcceptHeaderKey, AcceptHeaderValue);

--- a/src/tests/test_http_client_service.cpp
+++ b/src/tests/test_http_client_service.cpp
@@ -24,14 +24,11 @@ BOOST_AUTO_TEST_SUITE(test_http_client_service_suite)
 
     BOOST_AUTO_TEST_CASE(test_http_client_service_get)
     {
-        constexpr auto kasUrl = "https://api-develop01.develop.virtru.com/kas";
+        constexpr auto kasUrl = "https://www.virtru.com";
         constexpr auto AcceptHeaderKey = "Accept";
         constexpr auto AcceptHeaderValue = "application/json";
         constexpr auto UserAgentHeaderKey = "User-Agent";
-        constexpr auto UserAgentValuePostFix = "Virtru TDF C++ SDK v0.1";
-
-        //"Content-Type": "application/json"
-
+        constexpr auto UserAgentValuePostFix = virtru::Utils::getUserAgentValuePostFix();
 
         auto service = Service::Create(kasUrl);
         service->AddHeader(AcceptHeaderKey, AcceptHeaderValue);
@@ -64,64 +61,6 @@ BOOST_AUTO_TEST_SUITE(test_http_client_service_suite)
         ioContext.run();
     }
 
-    BOOST_AUTO_TEST_CASE(test_http_client_service_get_enity_object)
-    {
-
-        constexpr auto getEntityUrl = "https://accounts-develop01.develop.virtru.com/api/entityobject";
-        //constexpr auto apiId = "2aadbfbd-b68e-4648-ae29-40b4df27ea50@tokens.virtru.com";
-        //constexpr auto apiSecret = "f1itK5XJ+M3Gbjzna8yyUXkhKjlqRvzxx2S0mnh6N8Y=";
-
-        constexpr auto AcceptHeaderKey = "Accept";
-        constexpr auto AcceptHeaderValue = "application/json";
-        constexpr auto UserAgentHeaderKey = "User-Agent";
-        constexpr auto UserAgentValuePostFix = "Virtru TDF C++ SDK v0.1";
-
-        // Set user agent (ex: <Mac OS/Linux>:Virtru TDF C++ SDK v0.1)
-        std::ostringstream sdkUserAgent;
-        sdkUserAgent << BOOST_PLATFORM << ":" << UserAgentValuePostFix;
-
-        auto service = Service::Create(getEntityUrl);
-        service->AddHeader(AcceptHeaderKey, AcceptHeaderValue);
-        service->AddHeader(UserAgentHeaderKey, sdkUserAgent.str());
-
-        constexpr auto publicKey = "-----BEGIN PUBLIC KEY-----\n"
-                                   "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAuO0nxhGCyuEbHOqNXjWI\n"
-                                   "2dfuNC9jz6J9ZKb3dvosZLtiro32+jgeeudcO0/l1P+RzGkORUGubrkN/oUWtC9l\n"
-                                   "DJgq3T05pQJUcg/+sbyL1GvUnU0iJfVk9zz5w3cDBE/I99rCGsIfG2m+unKKJn22\n"
-                                   "wd/ZOqQDOwZN6oDkB7ZWQJe0QBQub0lJjThogrPViXIJqRgToH+tsjUX+htkp8QA\n"
-                                   "vvkw09Xc1HZ6khZVdfYf7Bm0YI0OVCMbJ77BVsMG0cCsD/8h3/26F7oq9uiaeTnx\n"
-                                   "sZBszfBXJGpUm40naaQJ/4CIq20QTadrXLMp1CRMnR5TceLvv/KpGlQGXb4V4zRf\n"
-                                   "qQIDAQAB\n"
-                                   "-----END PUBLIC KEY-----";
-
-        nlohmann::json publicKeyBody;
-        publicKeyBody["publicKey"] = publicKey;
-
-        IOContext ioContext;
-        service->ExecutePost(to_string(publicKeyBody), ioContext, [](ErrorCode errorCode, HttpResponse&& response) {
-            if (errorCode) { // something wrong.
-
-                std::ostringstream os {"Error code: "};
-                os << errorCode.value() << " " << errorCode.message();
-                //BOOST_FAIL(os.str());
-
-                std::cerr << os.str() << std::endl;
-                auto body = response.body().data();
-                std::cerr << body << std::endl;
-                return;
-            }
-
-            BOOST_TEST_MESSAGE(response);
-
-            auto body = response.body().data();
-            std::cerr << body << std::endl;
-            //BOOST_TEST(body == "\"It's alive!!! It's alive!!!\"\n");
-            return;
-        });
-
-        // Run the context - It's blocking call until i/o operation is done.
-        ioContext.run();
-    }
 
     BOOST_AUTO_TEST_CASE(test_http_header_version_value)
     {


### PR DESCRIPTION
Don't use develop01 url to check basic http operation.  Also remove invalid test case with no result checks

Closes #108 