### PR TITLE
[PLAT-1649] Add include required by some compiler+platform combinations

### DIFF
--- a/src/lib/src/crypto/rsa_key_pair.cpp
+++ b/src/lib/src/crypto/rsa_key_pair.cpp
@@ -19,6 +19,7 @@
 #include <openssl/rand.h>
 #include <openssl/bio.h>
 #include <openssl/pem.h>
+#include <stdint.h>
 
 namespace virtru::crypto {
 


### PR DESCRIPTION
Add explicit include of stdint.h, as automated builds on conan-center-index complains on some combinations that std::uint8_t is not defined.