### PR TITLE
[PLAT-2809] fix swig go string storage type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 1.5.6
  - PLAT-2799 - Fix GCC13 complaint
+ - PLAT-2809 - Fix swig string storage type support
 
 1.5.5
  - PLAT-2676 - OpenTDF SDK created TDF without encryption

--- a/src/lib/include/oidc_credentials.h
+++ b/src/lib/include/oidc_credentials.h
@@ -47,11 +47,13 @@ namespace virtru {
         /// Copy constructor
         OIDCCredentials(const OIDCCredentials &oidcCredentials);
 
+#ifndef SWIG
         /// Move copy constructor
         OIDCCredentials(OIDCCredentials &&oidcCredentials);
 
         /// Move assignment operator
         OIDCCredentials &operator=(OIDCCredentials &&oidcCredentials);
+#endif
 
       public: // Public methods
         /// Set the secret client credentials that will be use for auth with OIDC server

--- a/src/lib/include/tdf_assertion.h
+++ b/src/lib/include/tdf_assertion.h
@@ -60,11 +60,13 @@ namespace virtru {
         /// Copy constructor
         StatementGroup(const StatementGroup &statementGroup) = default;
 
+#ifndef SWIG
         /// Move copy constructor
         StatementGroup(StatementGroup &&statementGroup) = default;
 
         /// Move assignment operator
         StatementGroup &operator=(StatementGroup &&statementGroup) = default;
+#endif
 
     public: /// Interface
         /// Set the statement type for the statement group
@@ -165,11 +167,13 @@ namespace virtru {
         /// Copy constructor
         Assertion(const Assertion &assertion) = default;
 
+#ifndef SWIG
         /// Move copy constructor
         Assertion(Assertion &&assertion) = default;
 
         /// Move assignment operator
         Assertion &operator=(Assertion &&assertion) = default;
+#endif
 
     public: /// Interface
 
@@ -227,7 +231,7 @@ namespace virtru {
             return m_appliesToState;
         }
 
-        /// Set the assertion has for the assertion.
+        /// Set the assertion hash for the assertion.
         /// \param assertionHash - The assertion hash value.
         void setAssertionHash(const std::string& assertionHash) {
             m_assertionHash = assertionHash;

--- a/src/lib/include/tdf_storage_type.h
+++ b/src/lib/include/tdf_storage_type.h
@@ -42,22 +42,22 @@ namespace virtru {
         /// Copy constructor
         TDFStorageType(const TDFStorageType &oidcCredentials);
 
+#ifndef SWIG
         /// Move copy constructor
         TDFStorageType(TDFStorageType &&oidcCredentials);
 
         /// Move assignment operator
         TDFStorageType &operator=(TDFStorageType &&oidcCredentials);
+#endif
 
     public:
         /// set the TDF storage type as type file.
         /// \param filePath - The file on which the tdf operations to be performed on
         void setTDFStorageFileType(const std::string& filePath);
 
-#ifndef SWIG
         /// set the TDF storage type as type string.
         /// \param str - The str container containing data to be encrypted or decrypted.
         void setTDFStorageStringType(const std::string& str);
-#endif
 
         /// set the TDF storage type as type buffer.
         /// \param buffer - The buffer container containing data to be encrypted or decrypted.


### PR DESCRIPTION
Change SWIG visibility to methods:
- expose string storage type
- hide unnecessary methods causing SWIG warnings