### PR TITLE
Disable Sonar scanner for forked PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,8 +82,10 @@ jobs:
             src/coverageGcovr.txt
             src/coverageGcovrSonar.xml
       - name: Install sonar-scanner and build-wrapper
+        if: github.event.pull_request.head.repo.full_name == github.repository
         uses: sonarsource/sonarcloud-github-c-cpp@v2
       - name: Run build-wrapper
+        if: github.event.pull_request.head.repo.full_name == github.repository
         run: |
           cd ${{ github.workspace }}
           # to be in folder containing conanfile

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,6 +91,7 @@ jobs:
           build-wrapper-linux-x86-64 --out-dir ${{ env.BUILD_WRAPPER_OUT_DIR_SONAR }} ./build-all.sh
           cp -r build_wrapper_output_directory /home/runner/work/client-cpp/client-cpp
       - name: Run sonar-scanner
+        if: github.event.pull_request.head.repo.full_name == github.repository
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
As a workaround to the issue caused by no secrets access for forked PRs (like this: https://github.com/opentdf/client-cpp/actions/runs/7999089709/job/21847259894)