### PR TITLE
Update http_service_provider.cpp

### DIFF
--- a/src/lib/src/network/http_service_provider.cpp
+++ b/src/lib/src/network/http_service_provider.cpp
@@ -57,7 +57,7 @@ namespace virtru::network {
             }
 
             // Not everything throws an errorCode
-            if ((!errorCode) && (status != kHTTPOk)) {
+            if ((!errorCode) && (status != kHTTPOk) && (status != kHTTPOkPartial)) {
                 std::ostringstream oss;
                 oss << "status: " << status << " " << responseBody;
                 LogDebug(oss.str());


### PR DESCRIPTION
add kHTTPOkPartial 206 http status code support. 
No output log when http status code is 206.
206 is ok too.